### PR TITLE
Fix: Prevent AttributeError for arguments in case law display

### DIFF
--- a/simple_streamlit_legal_research_assistant.py
+++ b/simple_streamlit_legal_research_assistant.py
@@ -1240,6 +1240,10 @@ def case_analysis_agent(gemini_model, papers: List[Dict[str, Any]]) -> List[Dict
                     paper['legal_issues'] = analysis_results.get('legal_issues', [])
                     paper['arguments'] = analysis_results.get('arguments', {"plaintiff": "Not available",
                                                                             "defendant": "Not available"})
+                    # Ensure 'arguments' is a dict with 'plaintiff' and 'defendant' keys
+                    if not isinstance(paper['arguments'], dict) or \
+                       not ('plaintiff' in paper['arguments'] and 'defendant' in paper['arguments']):
+                        paper['arguments'] = {"plaintiff": "Not available", "defendant": "Not available"}
                     paper['judgment'] = analysis_results.get('judgment', "Not available")
                     paper['court_findings'] = analysis_results.get('court_findings', "Not available")
                     processed_successfully = True
@@ -1748,6 +1752,8 @@ def main():
                         # Arguments
                         st.markdown("**3. Arguments:**")
                         arguments = case.get('arguments', {})
+                        if not isinstance(arguments, dict):
+                            arguments = {"plaintiff": "Error: Invalid argument data", "defendant": "Error: Invalid argument data"}
                         col1, col2 = st.columns(2)
                         with col1:
                             st.write("*Plaintiff/Appellant:*")


### PR DESCRIPTION
The `arguments` variable was sometimes a string instead of a dictionary, causing an `AttributeError: 'str' object has no attribute 'get'` when displaying plaintiff/defendant information for legal cases.

This commit addresses the issue by:
1. Strengthening `arguments` field validation in `case_analysis_agent` (Gemini version): Added a check to ensure `paper['arguments']` is a dictionary with 'plaintiff' and 'defendant' keys, resetting to a default if not.
2. Confirming robust validation in `case_analysis_agent_ollama`: Ensured existing checks correctly handle malformed API responses for the `arguments` field.
3. Adding a safety check in `main`: Before accessing `arguments.get()`, verify `arguments` is a dictionary. If not, use a default error dictionary. This acts as a fallback to prevent UI crashes.